### PR TITLE
mpan should be mprn to match the path param

### DIFF
--- a/octopus-energy-api.yaml
+++ b/octopus-energy-api.yaml
@@ -600,7 +600,7 @@ paths:
       security:
         - basicAuth: []
       parameters:
-        - name: mpan
+        - name: mprn
           in: path
           required: true
           schema:


### PR DESCRIPTION
There was an error when loading in the spec file into the swagger editor https://editor.swagger.io/ because the gas endpoint uses mprn rather than mpan and I'd copy and pasted the electricity  endpoint spec